### PR TITLE
fix: OpenClaw plugin wiring — config, MemoryManager, keyID, tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
     "./tools": {
       "types": "./dist/agent/tools/types.d.ts",
       "default": "./dist/agent/tools/types.js"
+    },
+    "./plugins/builtin": {
+      "types": "./dist/plugins/builtin/index.d.ts",
+      "default": "./dist/plugins/builtin/index.js"
     }
   },
   "scripts": {

--- a/packages/openclaw-plugin/__tests__/config.test.ts
+++ b/packages/openclaw-plugin/__tests__/config.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+import { resolveConfig, AGiDPluginConfigSchema } from '../src/config.js';
+
+describe('resolveConfig', () => {
+  it('returns full config when all fields provided', async () => {
+    const input = {
+      network: 'testnet',
+      storage: 'local',
+      storagePath: '/custom/path.sqlite',
+      messageboxHost: 'https://custom.messagebox.com',
+      uhrpStorageUrl: 'https://custom.uhrp.com',
+      walletClientUrl: 'http://localhost:9999',
+      trustedCertifiers: ['02abc123'],
+      requireCerts: true,
+    };
+    const result = await resolveConfig(input);
+    expect(result).toEqual(input);
+  });
+
+  it('applies defaults for optional fields', async () => {
+    const result = await resolveConfig({ network: 'testnet' });
+    expect(result.network).toBe('testnet');
+    expect(result.storage).toBe('local');
+    expect(result.storagePath).toBe('~/.agid/wallet.sqlite');
+    expect(result.messageboxHost).toBe('https://messagebox.babbage.systems');
+    expect(result.uhrpStorageUrl).toBe('https://go-uhrp.b1nary.cloud');
+    expect(result.walletClientUrl).toBe('http://localhost:3301');
+    expect(result.trustedCertifiers).toEqual([]);
+    expect(result.requireCerts).toBe(false);
+  });
+
+  it('prompts for network when missing and prompt function available', async () => {
+    const promptFn = vi.fn().mockResolvedValue('mainnet');
+    const result = await resolveConfig({}, promptFn);
+    expect(promptFn).toHaveBeenCalledWith('AGiD network (mainnet/testnet):');
+    expect(result.network).toBe('mainnet');
+  });
+
+  it('throws when network missing and no prompt function', async () => {
+    await expect(resolveConfig({})).rejects.toThrow(
+      "AGiD requires 'network' to be set"
+    );
+  });
+
+  it('rejects invalid network value', async () => {
+    await expect(resolveConfig({ network: 'devnet' })).rejects.toThrow();
+  });
+
+  it('rejects invalid network from prompt', async () => {
+    const promptFn = vi.fn().mockResolvedValue('devnet');
+    await expect(resolveConfig({}, promptFn)).rejects.toThrow();
+  });
+
+  it('logs warnings for fields using defaults', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await resolveConfig({ network: 'testnet' });
+    expect(warnSpy).toHaveBeenCalled();
+    const warnings = warnSpy.mock.calls.map(c => c[0]);
+    expect(warnings.some((w: string) => w.includes('storage'))).toBe(true);
+    warnSpy.mockRestore();
+  });
+});

--- a/packages/openclaw-plugin/__tests__/config.test.ts
+++ b/packages/openclaw-plugin/__tests__/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { resolveConfig, AGiDPluginConfigSchema } from '../src/config.js';
+import { resolveConfig } from '../src/config.js';
 
 describe('resolveConfig', () => {
   it('returns full config when all fields provided', async () => {

--- a/packages/openclaw-plugin/__tests__/index.test.ts
+++ b/packages/openclaw-plugin/__tests__/index.test.ts
@@ -14,24 +14,30 @@ describe('@agid/openclaw-plugin', () => {
       registerTool(tool: any, options?: any) {
         registeredTools.push({ name: tool.name, group: options?.group });
       },
-      config: {},
+      config: { network: 'testnet' },
     };
 
     await openclawPlugin.register(mockApi);
 
-    // Should register tools from all 11 builtin plugins
-    // audit(2) + optimize(1) + messaging(5) + crypto(5) + wallet(7) + memory(4) + identity(18) + deploy(8) + runtime(2) + fs(4) + browser(1) = 57
-    expect(registeredTools.length).toBeGreaterThanOrEqual(50);
+    // Should register tools from 6 plugins (identity, crypto, wallet, messaging, memory, audit)
+    // audit(2) + messaging(5) + crypto(5) + wallet(7) + memory(4) + identity(18) = 41
+    // minus excluded: agid_gc_legacy_tokens = 40
+    expect(registeredTools.length).toBeGreaterThanOrEqual(38);
 
-    // Check some key tool names exist
+    // Check core AGiD tool names exist
     const names = registeredTools.map(t => t.name);
     expect(names).toContain('agid_verify_workspace');
     expect(names).toContain('agid_sign');
     expect(names).toContain('agid_token_create');
     expect(names).toContain('agid_identity');
-    expect(names).toContain('exec');
-    expect(names).toContain('read');
-    expect(names).toContain('browser');
+
+    // These should NOT be registered (OpenClaw provides its own)
+    expect(names).not.toContain('exec');
+    expect(names).not.toContain('read');
+    expect(names).not.toContain('browser');
+    expect(names).not.toContain('agid_optimize_prompt');
+    expect(names).not.toContain('agid_mandala_create_project');
+    expect(names).not.toContain('agid_gc_legacy_tokens');
   });
 
   it('has destroy method', () => {

--- a/packages/openclaw-plugin/__tests__/index.test.ts
+++ b/packages/openclaw-plugin/__tests__/index.test.ts
@@ -20,9 +20,9 @@ describe('@agid/openclaw-plugin', () => {
     await openclawPlugin.register(mockApi);
 
     // Should register tools from 6 plugins (identity, crypto, wallet, messaging, memory, audit)
-    // audit(2) + messaging(5) + crypto(5) + wallet(7) + memory(4) + identity(18) = 41
-    // minus excluded: agid_gc_legacy_tokens = 40
-    expect(registeredTools.length).toBeGreaterThanOrEqual(38);
+    // audit(2) + messaging(5) + crypto(5) + wallet(7) + memory(2) + identity(18) = 39
+    // minus excluded: agid_gc_legacy_tokens = 38
+    expect(registeredTools.length).toBeGreaterThanOrEqual(36);
 
     // Check core AGiD tool names exist
     const names = registeredTools.map(t => t.name);
@@ -38,6 +38,8 @@ describe('@agid/openclaw-plugin', () => {
     expect(names).not.toContain('agid_optimize_prompt');
     expect(names).not.toContain('agid_mandala_create_project');
     expect(names).not.toContain('agid_gc_legacy_tokens');
+    expect(names).not.toContain('shad_deep_recall');
+    expect(names).not.toContain('shad_search_memories');
   });
 
   it('has destroy method', () => {

--- a/packages/openclaw-plugin/__tests__/integration.test.ts
+++ b/packages/openclaw-plugin/__tests__/integration.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { MockAgentWallet } from './mock-wallet.js';
+
+// We must mock wallet-init BEFORE importing the plugin so the proxy's
+// getWallet() returns our MockAgentWallet instead of a real BSV wallet.
+let currentMockWallet: MockAgentWallet;
+
+vi.mock('../src/wallet-init.js', () => ({
+  initWallet: async () => currentMockWallet,
+  destroyWallet: async () => {},
+}));
+
+// Dynamic import after mock is in place
+const { default: openclawPlugin } = await import('../index.js');
+
+/**
+ * Helper: register the plugin with a mock API and return registered tools.
+ */
+async function setupPlugin(mockWallet: MockAgentWallet) {
+  const registeredTools = new Map<string, { tool: any; options?: any }>();
+
+  const mockApi = {
+    registerTool(tool: any, options?: any) {
+      registeredTools.set(tool.name, { tool, options });
+    },
+    config: { network: 'testnet' },
+    prompt: undefined,
+  };
+
+  await openclawPlugin.register(mockApi);
+
+  return {
+    registeredTools,
+    async exec(toolName: string, params: Record<string, unknown> = {}) {
+      const entry = registeredTools.get(toolName);
+      if (!entry) throw new Error(`Tool "${toolName}" not registered`);
+      return entry.tool.execute(toolName, params, {});
+    },
+    async execJson(toolName: string, params: Record<string, unknown> = {}) {
+      const result = await this.exec(toolName, params);
+      const text = result.content?.[0]?.text;
+      if (!text) throw new Error(`Tool "${toolName}" returned no text content`);
+      return JSON.parse(text);
+    },
+  };
+}
+
+describe('OpenClaw Plugin Integration', () => {
+  let wallet: MockAgentWallet;
+  let plugin: Awaited<ReturnType<typeof setupPlugin>>;
+
+  beforeEach(async () => {
+    wallet = new MockAgentWallet('testnet');
+    currentMockWallet = wallet;
+    plugin = await setupPlugin(wallet);
+  });
+
+  describe('wallet context injection', () => {
+    it('marks identity tool as requiresWallet', () => {
+      const identityTool = plugin.registeredTools.get('agid_identity');
+      expect(identityTool).toBeDefined();
+      expect(identityTool!.tool.requiresWallet).toBe(true);
+    });
+
+    it('marks zkproof_verify as not requiring wallet', () => {
+      const verifyTool = plugin.registeredTools.get('agid_zkproof_verify');
+      expect(verifyTool).toBeDefined();
+      expect(verifyTool!.tool.requiresWallet).toBe(false);
+    });
+  });
+
+  describe('sign and encrypt round-trip', () => {
+    it('signs a message and returns hex signature', async () => {
+      const result = await plugin.execJson('agid_sign', { message: 'hello world' });
+      expect(result.signed).toBe(true);
+      expect(result.signature).toBeDefined();
+      expect(typeof result.signature).toBe('string');
+      expect(result.signature).toMatch(/^[0-9a-f]+$/i);
+    });
+
+    it('encrypts and decrypts data with matching keys', async () => {
+      const plaintext = 'secret agent data';
+      const encrypted = await plugin.execJson('agid_encrypt', { data: plaintext });
+      expect(encrypted.encrypted).toBe(true);
+      expect(encrypted.ciphertext).toBeDefined();
+      expect(encrypted.ciphertext).not.toBe(plaintext);
+
+      const decrypted = await plugin.execJson('agid_decrypt', { ciphertext: encrypted.ciphertext });
+      expect(decrypted.decrypted).toBe(true);
+      expect(decrypted.plaintext).toBe(plaintext);
+    });
+  });
+
+  describe('identity info', () => {
+    it('returns public key and network', async () => {
+      const result = await plugin.execJson('agid_identity', {});
+      expect(result.publicKey).toBeDefined();
+      expect(typeof result.publicKey).toBe('string');
+      expect(result.publicKey).toMatch(/^0[23][0-9a-f]{64}$/i);
+      expect(result.network).toBe('testnet');
+    });
+  });
+
+  describe('excluded tools', () => {
+    const MUST_BE_ABSENT = [
+      'exec', 'process', 'read', 'write', 'edit', 'apply_patch', 'browser',
+      'agid_optimize_prompt',
+      'agid_mandala_create_project', 'agid_mandala_list_projects',
+      'agid_mandala_project_info', 'agid_mandala_deploy',
+      'agid_mandala_update_settings', 'agid_mandala_project_logs',
+      'agid_mandala_manage_admins', 'agid_mandala_node_info',
+      'agid_gc_legacy_tokens', 'shad_deep_recall', 'shad_search_memories',
+    ];
+
+    for (const toolName of MUST_BE_ABSENT) {
+      it(`does not register "${toolName}"`, () => {
+        expect(plugin.registeredTools.has(toolName)).toBe(false);
+      });
+    }
+  });
+});

--- a/packages/openclaw-plugin/__tests__/mock-wallet.ts
+++ b/packages/openclaw-plugin/__tests__/mock-wallet.ts
@@ -1,0 +1,149 @@
+/**
+ * Stateful mock wallet for integration tests.
+ *
+ * Tracks outputs, tokens, and memory state so tests can verify
+ * that the plugin's proxy wiring actually passes data through correctly.
+ * Uses consistent data transformations (hex encoding, Buffer round-trips)
+ * but does NOT perform real cryptographic operations.
+ */
+
+interface MockOutput {
+  outpoint: string;
+  satoshis: number;
+  lockingScript: string;
+  basket?: string;
+  tags?: string[];
+  customInstructions?: string;
+  spendable: boolean;
+}
+
+let txCounter = 0;
+
+export class MockAgentWallet {
+  private publicKey = '02' + 'ab'.repeat(32);
+  private networkValue: 'mainnet' | 'testnet';
+  private outputs: MockOutput[] = [];
+  private balanceValue = 100000;
+
+  constructor(network: 'mainnet' | 'testnet' = 'testnet') {
+    this.networkValue = network;
+  }
+
+  async getPublicKey(args: { identityKey?: boolean; protocolID?: [number, string]; keyID?: string }) {
+    if (args.protocolID && args.keyID) {
+      const derived = '03' + Buffer.from(
+        `${args.protocolID[1]}-${args.keyID}`.padEnd(32, '0')
+      ).toString('hex').slice(0, 64);
+      return { publicKey: derived };
+    }
+    return { publicKey: this.publicKey };
+  }
+
+  async encrypt(args: { plaintext: number[] | Uint8Array; protocolID: [number, string]; keyID: string; counterparty?: string }) {
+    const plainBytes = Array.isArray(args.plaintext) ? args.plaintext : Array.from(args.plaintext);
+    const marker = Buffer.from(`ENC:${args.protocolID[1]}:${args.keyID}:`);
+    const ciphertext = [...Array.from(marker), ...plainBytes];
+    return { ciphertext };
+  }
+
+  async decrypt(args: { ciphertext: number[] | Uint8Array; protocolID: [number, string]; keyID: string; counterparty?: string }) {
+    const cipherBytes = Array.isArray(args.ciphertext) ? args.ciphertext : Array.from(args.ciphertext);
+    const marker = `ENC:${args.protocolID[1]}:${args.keyID}:`;
+    const markerBytes = Array.from(Buffer.from(marker));
+    const actualMarker = Buffer.from(cipherBytes.slice(0, markerBytes.length)).toString();
+    if (actualMarker !== marker) {
+      throw new Error(`Decrypt failed: key mismatch. Expected marker "${marker}", got "${actualMarker}"`);
+    }
+    const plaintext = cipherBytes.slice(markerBytes.length);
+    return { plaintext };
+  }
+
+  async createSignature(args: { data: number[] | Uint8Array; protocolID: [number, string]; keyID: string }) {
+    const dataBytes = Array.isArray(args.data) ? args.data : Array.from(args.data);
+    const sigInput = `SIG:${args.protocolID[1]}:${args.keyID}:${Buffer.from(dataBytes).toString('hex')}`;
+    const signature = Array.from(Buffer.from(sigInput));
+    return { signature };
+  }
+
+  async verifySignature(args: { data: number[] | Uint8Array; signature: number[] | Uint8Array; protocolID: [number, string]; keyID: string }) {
+    const dataBytes = Array.isArray(args.data) ? args.data : Array.from(args.data);
+    const expected = `SIG:${args.protocolID[1]}:${args.keyID}:${Buffer.from(dataBytes).toString('hex')}`;
+    const actual = Buffer.from(Array.isArray(args.signature) ? args.signature : Array.from(args.signature)).toString();
+    return { valid: actual === expected };
+  }
+
+  async createHmac(args: { data: number[] | Uint8Array; protocolID: [number, string]; keyID: string }) {
+    const dataBytes = Array.isArray(args.data) ? args.data : Array.from(args.data);
+    const hmacInput = `HMAC:${args.protocolID[1]}:${args.keyID}:${Buffer.from(dataBytes).toString('hex')}`;
+    return { hmac: Array.from(Buffer.from(hmacInput)) };
+  }
+
+  async verifyHmac(args: { data: number[] | Uint8Array; hmac: number[] | Uint8Array; protocolID: [number, string]; keyID: string }) {
+    const dataBytes = Array.isArray(args.data) ? args.data : Array.from(args.data);
+    const expected = `HMAC:${args.protocolID[1]}:${args.keyID}:${Buffer.from(dataBytes).toString('hex')}`;
+    const actual = Buffer.from(Array.isArray(args.hmac) ? args.hmac : Array.from(args.hmac)).toString();
+    return { valid: actual === expected };
+  }
+
+  async createAction(args: {
+    description: string;
+    outputs?: Array<{ script: string; satoshis: number; description?: string; basket?: string; tags?: string[]; customInstructions?: string }>;
+    inputs?: Array<{ outpoint: string; unlockingScript?: string; inputDescription?: string }>;
+  }) {
+    const txid = `mock_tx_${++txCounter}_${Date.now().toString(16)}`;
+    if (args.inputs) {
+      for (const input of args.inputs) {
+        const output = this.outputs.find(o => o.outpoint === input.outpoint && o.spendable);
+        if (!output) throw new Error(`Output not found or already spent: ${input.outpoint}`);
+        output.spendable = false;
+        this.balanceValue += output.satoshis;
+      }
+    }
+    if (args.outputs) {
+      args.outputs.forEach((out, i) => {
+        this.outputs.push({
+          outpoint: `${txid}.${i}`,
+          satoshis: out.satoshis,
+          lockingScript: out.script,
+          basket: out.basket,
+          tags: out.tags,
+          customInstructions: out.customInstructions,
+          spendable: true,
+        });
+        this.balanceValue -= out.satoshis;
+      });
+    }
+    return { txid };
+  }
+
+  async listOutputs(args: { basket: string; tags?: string[]; include?: string }) {
+    const filtered = this.outputs.filter(o => {
+      if (o.basket !== args.basket) return false;
+      if (!o.spendable) return false;
+      if (args.tags && args.tags.length > 0) {
+        if (!o.tags || !args.tags.every(t => o.tags!.includes(t))) return false;
+      }
+      return true;
+    });
+    return {
+      totalOutputs: filtered.length,
+      outputs: filtered.map(o => ({
+        outpoint: o.outpoint,
+        satoshis: o.satoshis,
+        lockingScript: o.lockingScript,
+        customInstructions: o.customInstructions,
+        spendable: o.spendable,
+      })),
+    };
+  }
+
+  async acquireCertificate() { return { certificate: {} as any }; }
+  async listCertificates() { return { totalCertificates: 0, certificates: [] }; }
+  async getNetwork() { return this.networkValue; }
+  async getHeight() { return 800000; }
+  async isAuthenticated() { return true; }
+  async getBalance() { return this.balanceValue; }
+  getMessageBoxClient() { return null; }
+  getUnderlyingWallet() { return null; }
+  asWalletInterface(): any { return this; }
+}

--- a/packages/openclaw-plugin/index.ts
+++ b/packages/openclaw-plugin/index.ts
@@ -7,6 +7,7 @@
 
 import { initWallet, destroyWallet } from './src/wallet-init.js';
 import { resolveConfig } from './src/config.js';
+import { MemoryManager } from 'agidentity';
 
 // Import only the plugins that provide AGiD's unique value (identity, crypto,
 // wallet, messaging, memory, audit).  OpenClaw already ships its own shell,
@@ -30,6 +31,8 @@ const ALL_PLUGINS = [
   agidMemoryPlugin,
   agidIdentityPlugin,
 ];
+
+let memoryManagerInstance: MemoryManager | null = null;
 
 /**
  * OpenClaw plugin entry point.
@@ -58,10 +61,24 @@ export default {
       return walletPromise;
     };
 
+    // Lazy MemoryManager initialization — only init when a memory tool is called
+    const getMemoryManager = async () => {
+      if (!memoryManagerInstance) {
+        const wallet = await getWallet();
+        memoryManagerInstance = new MemoryManager(wallet, {
+          workspacePath: resolvedConfig.storagePath,
+        });
+      }
+      return memoryManagerInstance;
+    };
+
     // Tools to exclude from the OpenClaw plugin (maintenance utilities
-    // that don't belong in the public distribution).
+    // that don't belong in the public distribution, and Shad tools
+    // since Shad is not included in the plugin).
     const EXCLUDED_TOOLS = new Set([
       'agid_gc_legacy_tokens',
+      'shad_deep_recall',
+      'shad_search_memories',
     ]);
 
     // Create a proxy API that passes wallet context to tools
@@ -78,6 +95,10 @@ export default {
               const wallet = await getWallet();
               ctx = { ...ctx, wallet };
             }
+            // Ensure MemoryManager is initialized for memory tools
+            if (options?.group === 'memory') {
+              await getMemoryManager();
+            }
             return originalExecute(id, params, ctx);
           },
         };
@@ -85,7 +106,8 @@ export default {
       },
       config: api.config,
       agid: {
-        wallet: null, // Will be set lazily
+        get memoryManager() { return memoryManagerInstance; },
+        wallet: null,
         audit: null,
         identity: null,
       },
@@ -98,6 +120,7 @@ export default {
   },
 
   async destroy() {
+    memoryManagerInstance = null;
     await destroyWallet();
     // Destroy any plugins that have cleanup
     for (const plugin of ALL_PLUGINS) {

--- a/packages/openclaw-plugin/index.ts
+++ b/packages/openclaw-plugin/index.ts
@@ -6,34 +6,29 @@
  */
 
 import { initWallet, destroyWallet } from './src/wallet-init.js';
-import type { WalletConfig } from './src/wallet-init.js';
+import { resolveConfig } from './src/config.js';
 
-// Import all builtin plugin definitions
-// These are re-exported from the main agidentity package
-import { agidAuditPlugin } from '../../src/plugins/builtin/agid-audit.js';
-import { agidOptimizePlugin } from '../../src/plugins/builtin/agid-optimize.js';
-import { agidMessagingPlugin } from '../../src/plugins/builtin/agid-messaging.js';
-import { agidCryptoPlugin } from '../../src/plugins/builtin/agid-crypto.js';
-import { agidWalletPlugin } from '../../src/plugins/builtin/agid-wallet.js';
-import { agidMemoryPlugin } from '../../src/plugins/builtin/agid-memory.js';
-import { agidIdentityPlugin } from '../../src/plugins/builtin/agid-identity.js';
-import { agidDeployPlugin } from '../../src/plugins/builtin/agid-deploy.js';
-import { agidRuntimePlugin } from '../../src/plugins/builtin/agid-runtime.js';
-import { agidFsPlugin } from '../../src/plugins/builtin/agid-fs.js';
-import { agidBrowserPlugin } from '../../src/plugins/builtin/agid-browser.js';
-
-const ALL_PLUGINS = [
+// Import only the plugins that provide AGiD's unique value (identity, crypto,
+// wallet, messaging, memory, audit).  OpenClaw already ships its own shell,
+// file-system, and browser tools, so agid-runtime, agid-fs, and agid-browser
+// are omitted.  agid-optimize (GEPA) and agid-deploy (Mandala infra) are
+// outside the plugin's scope.
+import {
   agidAuditPlugin,
-  agidOptimizePlugin,
   agidMessagingPlugin,
   agidCryptoPlugin,
   agidWalletPlugin,
   agidMemoryPlugin,
   agidIdentityPlugin,
-  agidDeployPlugin,
-  agidRuntimePlugin,
-  agidFsPlugin,
-  agidBrowserPlugin,
+} from 'agidentity/plugins/builtin';
+
+const ALL_PLUGINS = [
+  agidAuditPlugin,
+  agidMessagingPlugin,
+  agidCryptoPlugin,
+  agidWalletPlugin,
+  agidMemoryPlugin,
+  agidIdentityPlugin,
 ];
 
 /**
@@ -47,21 +42,33 @@ export default {
   name: 'AGiD — Auditable Agent Identity',
 
   async register(api: any) {
-    // Read config from OpenClaw
-    const config: Partial<WalletConfig> = api.config ?? {};
+    // Resolve and validate config
+    const resolvedConfig = await resolveConfig(api.config ?? {}, api.prompt);
 
     // Lazy wallet initialization — only init when a tool actually needs it
     let walletPromise: Promise<any> | null = null;
     const getWallet = async () => {
       if (!walletPromise) {
-        walletPromise = initWallet(config);
+        walletPromise = initWallet({
+          network: resolvedConfig.network,
+          storage: resolvedConfig.storage,
+          storagePath: resolvedConfig.storagePath,
+        });
       }
       return walletPromise;
     };
 
+    // Tools to exclude from the OpenClaw plugin (maintenance utilities
+    // that don't belong in the public distribution).
+    const EXCLUDED_TOOLS = new Set([
+      'agid_gc_legacy_tokens',
+    ]);
+
     // Create a proxy API that passes wallet context to tools
     const proxyApi = {
       registerTool(tool: any, options?: any) {
+        if (EXCLUDED_TOOLS.has(tool.name)) return;
+
         const originalExecute = tool.execute;
         const wrappedTool = {
           ...tool,

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -13,9 +13,11 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "agidentity": "workspace:*",
     "@bsv/sdk": "^2.0.3",
     "@bsv/wallet-toolbox": "^2.0.19",
-    "peercert": "^0.1.4"
+    "peercert": "^0.1.4",
+    "zod": "^3.23.0"
   },
   "peerDependencies": {
     "openclaw": "*"

--- a/packages/openclaw-plugin/src/config.ts
+++ b/packages/openclaw-plugin/src/config.ts
@@ -1,0 +1,68 @@
+/**
+ * AGiD OpenClaw Plugin Configuration
+ *
+ * Zod-validated config with defaults for optional fields and
+ * interactive prompting for required fields.
+ */
+
+import { z } from 'zod';
+
+export const AGiDPluginConfigSchema = z.object({
+  network: z.enum(['mainnet', 'testnet']),
+  storage: z.enum(['local', 'cloud']).default('local'),
+  storagePath: z.string().default('~/.agid/wallet.sqlite'),
+  messageboxHost: z.string().url().default('https://messagebox.babbage.systems'),
+  uhrpStorageUrl: z.string().url().default('https://go-uhrp.b1nary.cloud'),
+  walletClientUrl: z.string().url().default('http://localhost:3301'),
+  trustedCertifiers: z.array(z.string()).default([]),
+  requireCerts: z.boolean().default(false),
+});
+
+export type AGiDPluginConfig = z.infer<typeof AGiDPluginConfigSchema>;
+
+type PromptFn = (message: string) => Promise<string>;
+
+const DEFAULTS_USED: Array<{ field: string; value: string }> = [
+  { field: 'storage', value: 'local' },
+  { field: 'storagePath', value: '~/.agid/wallet.sqlite' },
+  { field: 'messageboxHost', value: 'https://messagebox.babbage.systems' },
+  { field: 'uhrpStorageUrl', value: 'https://go-uhrp.b1nary.cloud' },
+  { field: 'walletClientUrl', value: 'http://localhost:3301' },
+  { field: 'trustedCertifiers', value: '[]' },
+  { field: 'requireCerts', value: 'false' },
+];
+
+/**
+ * Resolve and validate plugin configuration.
+ *
+ * - Prompts for `network` if missing and a prompt function is available.
+ * - Throws if `network` is missing and no prompt function is available.
+ * - Logs warnings for optional fields falling back to defaults.
+ */
+export async function resolveConfig(
+  raw: Record<string, unknown> = {},
+  promptFn?: PromptFn,
+): Promise<AGiDPluginConfig> {
+  const input = { ...raw };
+
+  // Handle missing required field: network
+  if (!input.network) {
+    if (promptFn) {
+      const answer = await promptFn('AGiD network (mainnet/testnet):');
+      input.network = answer.trim();
+    } else {
+      throw new Error(
+        "AGiD requires 'network' to be set. Run: openclaw config set agid.network mainnet",
+      );
+    }
+  }
+
+  // Log warnings for optional fields using defaults
+  for (const { field, value } of DEFAULTS_USED) {
+    if (!(field in input) || input[field] === undefined) {
+      console.warn(`[AGiD] "${field}" not configured, using default: ${value}`);
+    }
+  }
+
+  return AGiDPluginConfigSchema.parse(input);
+}

--- a/packages/openclaw-plugin/vitest.config.ts
+++ b/packages/openclaw-plugin/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vitest/config';
+import path from 'path';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      'agidentity/plugins/builtin': path.resolve(__dirname, '../../dist/plugins/builtin/index.js'),
+    },
+  },
   test: {
     globals: true,
     environment: 'node',

--- a/packages/openclaw-plugin/vitest.config.ts
+++ b/packages/openclaw-plugin/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   resolve: {
     alias: {
       'agidentity/plugins/builtin': path.resolve(__dirname, '../../dist/plugins/builtin/index.js'),
+      'agidentity': path.resolve(__dirname, '../../dist/index.js'),
     },
   },
   test: {

--- a/packages/openclaw-plugin/vitest.config.ts
+++ b/packages/openclaw-plugin/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['__tests__/**/*.test.ts'],
+    exclude: ['node_modules', 'dist'],
+    testTimeout: 30000,
+    hookTimeout: 10000,
+  },
+});

--- a/src/agent/skills/skill-store.ts
+++ b/src/agent/skills/skill-store.ts
@@ -235,7 +235,12 @@ export class SkillStore {
 
       // Decrypt the downloaded content
       // Use the keyID preserved from customInstructions at store time
-      const keyId = skill.keyID || `skill-${skill.name}`;
+      if (!skill.keyID) {
+        throw new Error(
+          `Cannot resolve body for skill "${skill.name}": missing keyID`,
+        );
+      }
+      const keyId = skill.keyID;
       const decrypted = await this.wallet.decrypt({
         ciphertext: Array.from(downloadResult.data),
         protocolID: SKILL_PROTOCOL_ID,


### PR DESCRIPTION
## Summary

Makes the `@agid/openclaw-plugin` package functional by fixing four blocking issues:

- **Typed config schema** — Replaces untyped `api.config` with Zod-validated `AGiDPluginConfig`. Required `network` field prompts interactively; optional fields have sensible defaults with logged warnings. (Closes #5)
- **MemoryManager wiring** — Lazy-initializes a `MemoryManager` and attaches it to `proxyApi.agid` via getter. Memory tools now function instead of silently returning errors. Shad-specific tools (`shad_deep_recall`, `shad_search_memories`) excluded from plugin scope. (Closes #2)
- **SkillStore keyID fix** — Removes broken fallback `skill-${name}` that never matched the stored key `skill-${name}-${timestamp}`. Now throws explicitly if keyID is missing. (Closes #3)
- **Integration tests** — 24 tests exercising tools through the proxy with a stateful `MockAgentWallet`. Validates sign round-trip, encrypt/decrypt round-trip, identity info, wallet context injection, and all 20 excluded tools. (Closes #4)

## Files changed

| File | Change |
|------|--------|
| `packages/openclaw-plugin/src/config.ts` | New — Zod schema + `resolveConfig()` |
| `packages/openclaw-plugin/index.ts` | Config wiring, MemoryManager, Shad exclusions |
| `packages/openclaw-plugin/package.json` | Added `zod` dep |
| `packages/openclaw-plugin/vitest.config.ts` | New — test config with module aliases |
| `packages/openclaw-plugin/__tests__/config.test.ts` | New — 7 config validation tests |
| `packages/openclaw-plugin/__tests__/index.test.ts` | Updated exclusion assertions |
| `packages/openclaw-plugin/__tests__/mock-wallet.ts` | New — stateful BRC100Wallet fake |
| `packages/openclaw-plugin/__tests__/integration.test.ts` | New — 24 integration tests |
| `src/agent/skills/skill-store.ts` | keyID fallback fix (line 238) |

## Test plan

- [x] 34/34 tests passing (`config: 7, index: 3, integration: 24`)
- [x] `tsc --noEmit` clean
- [ ] Manual verification: install plugin in OpenClaw, run `agid_identity`
- [ ] Manual verification: store and recall a memory through OpenClaw

🤖 Generated with [Claude Code](https://claude.com/claude-code)